### PR TITLE
Addressed package name changes of RDF layer for loader.

### DIFF
--- a/sansa-inference-spark/src/main/scala/net/sansa_stack/inference/spark/data/loader/RDFGraphLoader.scala
+++ b/sansa-inference-spark/src/main/scala/net/sansa_stack/inference/spark/data/loader/RDFGraphLoader.scala
@@ -209,7 +209,7 @@ object RDFGraphLoader {
   }
 
   def main(args: Array[String]): Unit = {
-    import net.sansa_stack.rdf.spark.io.rdf._
+    import net.sansa_stack.rdf.spark.io._
 
     val path = args(0)
     val lang = args(1) match {

--- a/sansa-inference-spark/src/main/scala/net/sansa_stack/inference/spark/forwardchaining/triples/ForwardRuleReasonerRDFSDataframe.scala
+++ b/sansa-inference-spark/src/main/scala/net/sansa_stack/inference/spark/forwardchaining/triples/ForwardRuleReasonerRDFSDataframe.scala
@@ -289,7 +289,7 @@ object ForwardRuleReasonerRDFSDataframe {
   def apply(session: SparkSession, parallelism: Int = 2): ForwardRuleReasonerRDFSDataframe = new ForwardRuleReasonerRDFSDataframe(session, parallelism)
 
   def main(args: Array[String]): Unit = {
-    import net.sansa_stack.rdf.spark.io.rdf._
+    import net.sansa_stack.rdf.spark.io._
 
     val parallelism = 2
 

--- a/sansa-inference-spark/src/test/scala/net/sansa_stack/inference/spark/loader/RDFLoadingTests.scala
+++ b/sansa-inference-spark/src/test/scala/net/sansa_stack/inference/spark/loader/RDFLoadingTests.scala
@@ -11,7 +11,7 @@ import org.scalatest.FunSuite
   */
 class RDFLoadingTests extends FunSuite with DataFrameSuiteBase {
 
-  import net.sansa_stack.rdf.spark.io.rdf._
+  import net.sansa_stack.rdf.spark.io._
 
   test("loading N-Triples file into DataFrame with REGEX parsing mode should result in 9 triples") {
     val sqlCtx = sqlContext


### PR DESCRIPTION
A package class was moved in RDF layer to follow Scala guidelines. This has been addressed in this PR.