### PR TITLE
Scala 2.12 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>net.sansa-stack</groupId>
-		<artifactId>sansa-parent</artifactId>
+		<artifactId>sansa-parent_2.12</artifactId>
 		<version>0.7.2-SNAPSHOT</version>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>net.sansa-stack</groupId>
-		<artifactId>sansa-parent_2.12</artifactId>
+		<artifactId>sansa-parent_2.11</artifactId>
 		<version>0.7.2-SNAPSHOT</version>
 	</parent>
 

--- a/sansa-inference-flink/src/main/scala/net/sansa_stack/inference/flink/forwardchaining/TransitiveReasoner.scala
+++ b/sansa-inference-flink/src/main/scala/net/sansa_stack/inference/flink/forwardchaining/TransitiveReasoner.scala
@@ -140,7 +140,7 @@ trait TransitiveReasoner extends Profiler{
           val terminate = prevPaths
             .coGroup(nextPaths)
             .where(0).equalTo(0) {
-            (prev, next, out: Collector[(Node, Node)]) => {
+            (prev: Iterator[(Node, Node)], next: Iterator[(Node, Node)], out: Collector[(Node, Node)]) => {
               val prevPaths = prev.toSet
               for (n <- next)
                 if (!prevPaths.contains(n)) out.collect(n)
@@ -166,7 +166,7 @@ trait TransitiveReasoner extends Profiler{
     var tc = edges
 
     // because join() joins on keys, in addition the pairs are stored in reversed order (o, s)
-    val edgesReversed = tc.map(t => (t._2, t._1))
+    val edgesReversed = tc.map((t: (A, A)) => (t._2, t._1))
 
     // the join is iterated until a fixed point is reached
     var i = 1
@@ -180,7 +180,7 @@ trait TransitiveReasoner extends Profiler{
       val join = tc.join(edgesReversed).where(0).equalTo(0)
       join.print()
       tc = tc
-        .union(join.map(x => (x._2._2, x._2._1)))
+        .union(join.map((x: ((A, A), (A, A))) => (x._2._2, x._2._1)))
         .distinct()
       nextCount = tc.count()
       i += 1

--- a/sansa-inference-flink/src/main/scala/net/sansa_stack/inference/flink/utils/DataSetUtils.scala
+++ b/sansa-inference-flink/src/main/scala/net/sansa_stack/inference/flink/utils/DataSetUtils.scala
@@ -27,7 +27,7 @@ object DataSetUtils {
       */
     def partitionBy(f: T => Boolean): (DataSet[T], DataSet[T]) = {
       val passes = dataset.filter(f)
-      val fails = dataset.filter(e => !f(e)) // Flink doesn't have filterNot
+      val fails = dataset.filter((e: T) => !f(e)) // Flink doesn't have filterNot
       (passes, fails)
     }
 

--- a/sansa-inference-flink/src/test/scala/net/sansa_stack/inference/flink/TCTest.scala
+++ b/sansa-inference-flink/src/test/scala/net/sansa_stack/inference/flink/TCTest.scala
@@ -179,7 +179,7 @@ class TCTest(mode: TestExecutionMode) extends MultipleProgramsTestBase(mode) {
         val terminate = prevPaths
           .coGroup(nextPaths)
           .where(0).equalTo(0) {
-          (prev, next, out: Collector[(String, String)]) => {
+          (prev: Iterator[(String, String)], next: Iterator[(String, String)], out: Collector[(String, String)]) => {
             val prevPaths = prev.toSet
             for (n <- next)
               if (!prevPaths.contains(n)) out.collect(n)


### PR DESCRIPTION
* changed parent name
* some Spark and Flink code had to be adapted because of ambiguous methods due to Java 8 lambda alignment within Scala 2.12 